### PR TITLE
Added rbenv binary path to puppet shim

### DIFF
--- a/lib/puppet/provider/rabbitmq_erlang_cookie/ruby.rb
+++ b/lib/puppet/provider/rabbitmq_erlang_cookie/ruby.rb
@@ -4,7 +4,7 @@ Puppet::Type.type(:rabbitmq_erlang_cookie).provide(:ruby) do
 
   defaultfor :feature => :posix
 
-  env_path = '/opt/puppetlabs/bin:/usr/local/bin:/usr/bin:/bin'
+  env_path = '/opt/puppetlabs/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/rbenv/shims'
   puppet_path = Puppet::Util.withenv(:PATH => env_path) do
     Puppet::Util.which('puppet')
   end


### PR DESCRIPTION
When puppet is installed from gem in a rbenv environment include a location to the shims directory to allow it to run.

Either this or include an input param for 'env_path' so it can be set when the class is called.