### PR TITLE
Updated repo.pp to remove puppetlabs Apt warnings

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -25,14 +25,12 @@ class rabbitmq::repo::apt(
   }
 
   apt::source { 'rabbitmq':
-    ensure       => $ensure_source,
-    location     => $location,
-    release      => $release,
-    repos        => $repos,
-    include_src  => $include_src,
-    key          => $key,
-    key_source   => $key_source,
-    key_content  => $key_content,
+    ensure      => $ensure_source,
+    location    => $location,
+    release     => $release,
+    repos       => $repos,
+    include     => { 'src' => $include_src },
+    key         => { 'id' => $key, 'source' => $key_source, 'content' =>  $key_content },
     architecture => $architecture,
   }
 


### PR DESCRIPTION
Puppetlabs Apt module now has deprecation warnings when call in the manner being used by the puppetlabs rabbitmq module. Updated and tested against puppetlabs apt module 2.2.2